### PR TITLE
modifing binding power of the unary "plus" and "dash"

### DIFF
--- a/src/parser/lookups.go
+++ b/src/parser/lookups.go
@@ -6,6 +6,7 @@ import (
 )
 
 type binding_power int
+
 const (
 	defalt_bp binding_power = iota
 	comma
@@ -20,9 +21,9 @@ const (
 	primary
 )
 
-type stmt_handler func (p *parser) ast.Stmt
-type nud_handler  func (p *parser) ast.Expr
-type led_handler  func (p *parser, left ast.Expr, bp binding_power) ast.Expr
+type stmt_handler func(p *parser) ast.Stmt
+type nud_handler func(p *parser) ast.Expr
+type led_handler func(p *parser, left ast.Expr, bp binding_power) ast.Expr
 
 type stmt_lookup map[lexer.TokenKind]stmt_handler
 type nud_lookup map[lexer.TokenKind]nud_handler
@@ -32,25 +33,24 @@ type bp_lookup map[lexer.TokenKind]binding_power
 var bp_lu = bp_lookup{}
 var nud_lu = nud_lookup{}
 var led_lu = led_lookup{}
-var stmt_lu =stmt_lookup{}
+var stmt_lu = stmt_lookup{}
 
-
-func led (kind lexer.TokenKind, bp binding_power, led_fn led_handler) {
+func led(kind lexer.TokenKind, bp binding_power, led_fn led_handler) {
 	bp_lu[kind] = bp
 	led_lu[kind] = led_fn
 }
 
-func nud (kind lexer.TokenKind, bp binding_power, nud_fn nud_handler) {
+func nud(kind lexer.TokenKind, bp binding_power, nud_fn nud_handler) {
 	bp_lu[kind] = primary
 	nud_lu[kind] = nud_fn
 }
 
-func stmt (kind lexer.TokenKind, stmt_fn stmt_handler) {
+func stmt(kind lexer.TokenKind, stmt_fn stmt_handler) {
 	bp_lu[kind] = defalt_bp
 	stmt_lu[kind] = stmt_fn
 }
 
-func createTokenLookups () {
+func createTokenLookups() {
 	// Assignment
 	led(lexer.ASSIGNMENT, assignment, parse_assignment_expr)
 	led(lexer.PLUS_EQUALS, assignment, parse_assignment_expr)
@@ -83,7 +83,8 @@ func createTokenLookups () {
 
 	// Unary/Prefix
 	nud(lexer.TYPEOF, unary, parse_prefix_expr)
-	nud(lexer.DASH, unary, parse_prefix_expr)
+	nud(lexer.DASH, additive, parse_prefix_expr)
+	nud(lexer.PLUS, additive, parse_prefix_expr)
 	nud(lexer.NOT, unary, parse_prefix_expr)
 	nud(lexer.OPEN_BRACKET, primary, parse_array_literal_expr)
 


### PR DESCRIPTION
Sense the binding power of the prefix "dash" was unary, it was above the binding power of multiplicative.
Therefore it would have higher precedence: 10 * 10 - 10, for this case the dash would be parsed as a unary and not the correct additive.
![image](https://github.com/user-attachments/assets/0ecc5e44-5c26-4600-889b-0383ff9d33b7)
As you can see the binary expression is parsed as a left for 10 and a right for the binary expression 10 - 10 which is wrong.
That is way in this commit I have changed the binding power of the token "dash" and added the token "plus" as prefix operations such as +10, -10 and modified their binding power to additive sense a "dash" prefix is identical to 0 - 10 and therefore should be parsed with the binding power of additive
